### PR TITLE
add OSM Scout Day/Night and English styles

### DIFF
--- a/maps/osmscout_day.json
+++ b/maps/osmscout_day.json
@@ -2,6 +2,6 @@
     "attribution": "<a href=\"https://github.com/rinigus/osmscout-server\">OSM Scout Server</a><br><a href=\"http://www.openstreetmap.org/copyright\">© OpenStreetMap</a>",
     "firstLabelLayer": "waterway-name",
     "format": "mapbox-gl",
-    "name": "OSM Scout",
+    "name": "OSM Scout Day",
     "styleUrl": "http://localhost:8553/v1/mbgl/style?style=osmbright"
 }

--- a/maps/osmscout_day_english.json
+++ b/maps/osmscout_day_english.json
@@ -1,0 +1,7 @@
+{
+    "attribution": "<a href=\"https://github.com/rinigus/osmscout-server\">OSM Scout Server</a><br><a href=\"http://www.openstreetmap.org/copyright\">© OpenStreetMap</a>",
+    "firstLabelLayer": "waterway-name",
+    "format": "mapbox-gl",
+    "name": "OSM Scout Day English",
+    "styleUrl": "http://localhost:8553/v1/mbgl/style?style=osmbright-en"
+}

--- a/maps/osmscout_night.json
+++ b/maps/osmscout_night.json
@@ -1,0 +1,7 @@
+{
+    "attribution": "<a href=\"https://github.com/rinigus/osmscout-server\">OSM Scout Server</a><br><a href=\"http://www.openstreetmap.org/copyright\">© OpenStreetMap</a>",
+    "firstLabelLayer": "waterway-name",
+    "format": "mapbox-gl",
+    "name": "OSM Scout Night",
+    "styleUrl": "http://localhost:8553/v1/mbgl/style?style=mc"
+}

--- a/maps/osmscout_night_english.json
+++ b/maps/osmscout_night_english.json
@@ -1,0 +1,7 @@
+{
+    "attribution": "<a href=\"https://github.com/rinigus/osmscout-server\">OSM Scout Server</a><br><a href=\"http://www.openstreetmap.org/copyright\">© OpenStreetMap</a>",
+    "firstLabelLayer": "waterway-name",
+    "format": "mapbox-gl",
+    "name": "OSM Scout Night English",
+    "styleUrl": "http://localhost:8553/v1/mbgl/style?style=mc-en"
+}


### PR DESCRIPTION
This PR adds support for day and night versions of OSM Scout Server Mapbox GL styles together with the versions that prefer English names over the local ones. Its not supported by the current released version of the server, but will be in the next one. I'll probably make a point release of OSM Scout Server in few days