### PR TITLE
OSM Scout Nearby search

### DIFF
--- a/guides/osmscout.py
+++ b/guides/osmscout.py
@@ -47,6 +47,7 @@ def nearby(query, near, radius, params):
     query = urllib.parse.quote_plus(query)
     limit = params.get("limit", 50)
     name = params.get("name", "")
+    name = urllib.parse.quote_plus(name)
     if isinstance(near, (list, tuple)):
         x, y = near[0], near[1]
         url = URL_XY.format(**locals())

--- a/guides/osmscout.py
+++ b/guides/osmscout.py
@@ -28,12 +28,14 @@ import urllib.parse
 URL_SEARCH = ("http://localhost:8553/v1/guide"
               "?limit={limit}"
               "&poitype={query}"
+              "&name={name}"
               "&radius={radius}"
               "&search={search}")
 
 URL_XY = ("http://localhost:8553/v1/guide"
           "?limit={limit}"
           "&poitype={query}"
+          "&name={name}"
           "&radius={radius}"
           "&lng={x}"
           "&lat={y}")
@@ -44,6 +46,7 @@ def nearby(query, near, radius, params):
     """Return X, Y and a list of dictionaries of places matching `query`."""
     query = urllib.parse.quote_plus(query)
     limit = params.get("limit", 50)
+    name = params.get("name", "")
     if isinstance(near, (list, tuple)):
         x, y = near[0], near[1]
         url = URL_XY.format(**locals())

--- a/guides/osmscout_name.qml
+++ b/guides/osmscout_name.qml
@@ -24,7 +24,6 @@ import "../qml/js/util.js" as Util
 Dialog {
     id: dialog
     allowedOrientations: app.defaultAllowedOrientations
-    canAccept: dialog.query.length > 0
 
     property var    history: []
     property string query: ""

--- a/guides/osmscout_name.qml
+++ b/guides/osmscout_name.qml
@@ -1,0 +1,135 @@
+/* -*- coding: utf-8-unix -*-
+ *
+ * Copyright (C) 2014 Osmo Salomaa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import "../qml"
+import "../qml/js/util.js" as Util
+
+Dialog {
+    id: dialog
+    allowedOrientations: app.defaultAllowedOrientations
+    canAccept: dialog.query.length > 0
+
+    property var    history: []
+    property string query: ""
+
+    SilicaListView {
+        id: listView
+        anchors.fill: parent
+        // Prevent list items from stealing focus.
+        currentIndex: -1
+
+        delegate: ListItem {
+            id: listItem
+            contentHeight: visible ? Theme.itemSizeSmall : 0
+            menu: contextMenu
+            visible: model.visible
+
+            ListItemLabel {
+                anchors.leftMargin: listView.searchField.textLeftMargin
+                color: listItem.highlighted ? Theme.highlightColor : Theme.primaryColor
+                height: Theme.itemSizeSmall
+                text: model.text
+            }
+
+            ContextMenu {
+                id: contextMenu
+                MenuItem {
+                    text: app.tr("Remove")
+                    onClicked: {
+                        py.call_sync("poor.app.history.remove_place_name", [model.name]);
+                        dialog.history = py.evaluate("poor.app.history.place_names");
+                        listView.model.remove(index);
+                    }
+                }
+            }
+
+            ListView.onRemove: animateRemoval(listItem);
+
+            onClicked: {
+                dialog.query = model.name;
+                dialog.accept();
+            }
+
+        }
+
+        header: Column {
+            height: dialogHeader.height + searchField.height
+            width: parent.width
+
+            DialogHeader {
+                id: dialogHeader
+            }
+
+            SearchField {
+                id: searchField
+                placeholderText: app.tr("Search")
+                width: parent.width
+                EnterKey.enabled: text.length > 0
+                EnterKey.onClicked: dialog.accept();
+                onTextChanged: {
+                    dialog.query = searchField.text;
+                    dialog.filterHistory();
+                }
+            }
+
+            Component.onCompleted: listView.searchField = searchField;
+
+        }
+
+        model: ListModel {}
+
+        property var searchField: undefined
+
+        ViewPlaceholder {
+            id: viewPlaceholder
+            enabled: false
+            hintText: app.tr("You can search for venues by name.")
+        }
+
+        VerticalScrollDecorator {}
+
+    }
+
+    onStatusChanged: {
+        if (dialog.status === PageStatus.Activating) {
+            dialog.loadHistory();
+            dialog.filterHistory();
+        }
+    }
+
+    function filterHistory() {
+        // Filter search history for current search field text.
+        var query = listView.searchField.text;
+        var found = Util.findMatches(query, dialog.history, listView.model.count);
+        Util.injectMatches(listView.model, found, "name", "text");
+        viewPlaceholder.enabled = found.length === 0;
+    }
+
+    function loadHistory() {
+        // Load search history and preallocate list items.
+        dialog.history = py.evaluate("poor.app.history.place_names");
+        while (listView.model.count < 100)
+            listView.model.append({"name": "",
+                                   "text": "",
+                                   "visible": false});
+
+    }
+
+}

--- a/guides/osmscout_settings.qml
+++ b/guides/osmscout_settings.qml
@@ -1,0 +1,41 @@
+/* -*- coding: utf-8-unix -*-
+ *
+ * Copyright (C) 2014 Osmo Salomaa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+Column {
+    ValueButton {
+        id: nameButton
+        label: app.tr("Name")
+        height: Theme.itemSizeSmall
+        value: ""
+        onClicked: {
+            var dialog = app.pageStack.push("osmscout_name.qml");
+            dialog.accepted.connect(function() {
+                nameButton.value = dialog.query;
+                page.params.name = dialog.query;
+                py.call_sync("poor.app.history.add_place_name", [dialog.query]);
+            });
+        }
+
+        Component.onCompleted: {
+            page.params.name = ""
+        }
+    }
+}

--- a/poor/history.py
+++ b/poor/history.py
@@ -34,6 +34,7 @@ class HistoryManager:
     def __init__(self):
         """Initialize a :class:`HistoryManager` instance."""
         self._path = os.path.join(poor.CONFIG_HOME_DIR, "search-history.json")
+        self._place_names = []
         self._place_types = []
         self._places = []
         self._read()
@@ -46,12 +47,24 @@ class HistoryManager:
         self.remove_place(place)
         self._places.insert(0, place)
 
+    def add_place_name(self, place_name):
+        """Add `place_name` to the list of place names."""
+        place_name = place_name.strip()
+        if not place_name: return
+        self.remove_place_name(place_name)
+        self._place_names.insert(0, place_name)
+
     def add_place_type(self, place_type):
         """Add `place_type` to the list of place types."""
         place_type = place_type.strip()
         if not place_type: return
         self.remove_place_type(place_type)
         self._place_types.insert(0, place_type)
+
+    @property
+    def place_names(self):
+        """Return a list of place names."""
+        return self._place_names[:]
 
     @property
     def place_types(self):
@@ -69,6 +82,7 @@ class HistoryManager:
             if os.path.isfile(self._path):
                 history = poor.util.read_json(self._path)
                 self._places = history.get("places", [])
+                self._place_names = history.get("place_names", [])
                 self._place_types = history.get("place_types", [])
         for place in self._places_blacklist:
             self.remove_place(place)
@@ -89,6 +103,13 @@ class HistoryManager:
             if self._places[i].lower() == place:
                 del self._places[i]
 
+    def remove_place_name(self, place_name):
+        """Remove `place_name` from the list of place names."""
+        place_name = place_name.strip().lower()
+        for i in reversed(range(len(self._place_names))):
+            if self._place_names[i].lower() == place_name:
+                del self._place_names[i]
+
     def remove_place_type(self, place_type):
         """Remove `place_type` from the list of place types."""
         place_type = place_type.strip().lower()
@@ -101,5 +122,6 @@ class HistoryManager:
         with poor.util.silent(Exception, tb=True):
             poor.util.write_json({
                 "places": self._places[:1000],
+                "place_names": self._place_names[:1000],
                 "place_types": self._place_types[:1000],
             }, self._path)

--- a/qml/NearbyResultsPage.qml
+++ b/qml/NearbyResultsPage.qml
@@ -134,16 +134,16 @@ Page {
             listView.visible = true;
             if (page.populated) return;
             var nearbyPage = app.pageStack.previousPage();
-            page.populate(nearbyPage.query, nearbyPage.near, nearbyPage.radius);
+            page.populate(nearbyPage.query, nearbyPage.near, nearbyPage.radius, nearbyPage.params);
         } else if (page.status === PageStatus.Inactive) {
             listView.visible = false;
         }
     }
 
-    function populate(query, near, radius) {
+    function populate(query, near, radius, params) {
         // Load nearby results from the Python backend.
         listView.model.clear();
-        py.call("poor.app.guide.nearby", [query, near, radius], function(results) {
+        py.call("poor.app.guide.nearby", [query, near, radius, params], function(results) {
             if (results && results.error && results.message) {
                 page.title = "";
                 busy.error = results.message;


### PR DESCRIPTION
I have separated _poitype_ and _name_ in the _guide_ search of OSM Scout Server. This is to distinguish when the user wants to find a cafe by name or just any cafe. Updated API is at https://github.com/rinigus/osmscout-server#poi-search-near-a-reference-position . This API will be available with the next release of OSM Scout Server. 

The idea is to extend type support via rinigus/geocoder-nlp#37 and, for that, I would need to separate names and types in the query.

This PR adds _name_ as one of the trackable inputs and uses it to specify name component of the query to OSM Scout Server. It doesn't change anything for the search by others. 