### PR TITLE
osmscout: list nearby types fetched from the server

### DIFF
--- a/guides/osmscout.py
+++ b/guides/osmscout.py
@@ -82,3 +82,6 @@ def parse_description(result):
     with poor.util.silent(Exception):
         items.append(result.admin_region)
     return ", ".join(items) or "–"
+
+def types():
+    return poor.http.get_json("http://localhost:8553/v1/poi_types")

--- a/guides/osmscout_settings.qml
+++ b/guides/osmscout_settings.qml
@@ -36,6 +36,7 @@ Column {
 
         Component.onCompleted: {
             page.params.name = ""
+            page.types = py.call_sync("poor.app.guide._provider.types")
         }
     }
 }

--- a/qml/NearbyPage.qml
+++ b/qml/NearbyPage.qml
@@ -31,6 +31,7 @@ Page {
     property string nearText: ""
     property string query: ""
     property var    params: {}
+    property var    types: []
     property real   radius: 1000
 
     // Offer a different selection of radii depending on the user's
@@ -67,6 +68,7 @@ Page {
                 onClicked: {
                     var dialog = app.pageStack.push("GuidePage.qml");
                     dialog.accepted.connect(function() {
+                        page.types = []
                         usingButton.value = py.evaluate("poor.app.guide.name");
                         column.addSetttings();
                     });
@@ -114,7 +116,7 @@ Page {
                 // Avoid putting label and value on different lines.
                 width: 3 * parent.width
                 onClicked: {
-                    var dialog = app.pageStack.push("PlaceTypePage.qml");
+                    var dialog = app.pageStack.push("PlaceTypePage.qml", { 'types': page.types } );
                     dialog.accepted.connect(function() {
                         page.query = dialog.query;
                     });
@@ -174,7 +176,9 @@ Page {
     }
 
     onQueryChanged: {
-        py.call_sync("poor.app.history.add_place_type", [page.query]);
+        if (page.types.length === 0) {
+            py.call_sync("poor.app.history.add_place_type", [page.query]);
+        }
     }
 
     onStatusChanged: {

--- a/qml/PlaceTypePage.qml
+++ b/qml/PlaceTypePage.qml
@@ -29,6 +29,7 @@ Dialog {
 
     property var    history: []
     property string query: ""
+    property var    types: []
 
     SilicaListView {
         id: listView
@@ -51,6 +52,7 @@ Dialog {
 
             ContextMenu {
                 id: contextMenu
+                enabled: dialog.types.length > 0
                 MenuItem {
                     text: app.tr("Remove")
                     onClicked: {
@@ -125,7 +127,11 @@ Dialog {
 
     function loadHistory() {
         // Load search history and preallocate list items.
-        dialog.history = py.evaluate("poor.app.history.place_types");
+        if (dialog.types.length > 0) {
+            dialog.history = dialog.types;
+        } else {
+            dialog.history = py.evaluate("poor.app.history.place_types");
+        }
         while (listView.model.count < 100)
             listView.model.append({"type": "",
                                    "text": "",

--- a/qml/PlaceTypePage.qml
+++ b/qml/PlaceTypePage.qml
@@ -52,13 +52,15 @@ Dialog {
 
             ContextMenu {
                 id: contextMenu
-                enabled: dialog.types.length > 0
                 MenuItem {
                     text: app.tr("Remove")
+                    enabled: dialog.types.length === 0
                     onClicked: {
-                        py.call_sync("poor.app.history.remove_place_type", [model.type]);
-                        dialog.history = py.evaluate("poor.app.history.place_types");
-                        listView.model.remove(index);
+                        if (dialog.types.length === 0) {
+                            py.call_sync("poor.app.history.remove_place_type", [model.type]);
+                            dialog.history = py.evaluate("poor.app.history.place_types");
+                            listView.model.remove(index);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is not as clean as I would like it, but maybe you have suggestion on how to improve it.

This PR incorporates list of geotag aliases when using OSM Scout Server as a provider for nearby search. On every start of nearby page, when using OSM Scout, a list of current aliases is fetched from the server and used instead of the history when specifying nearby type. In practice, on my device, it works fast and  I don't even recognize that something is pulled. 

Few not so clean things:

* internal _provider is used when getting the list
* history of type selections is not used when using the list from the server

The types list, as coming from the server, is not sorted. This I will change ASAP on the server side - its only one sorting while it is running.

We could also consider pulling the list once only. But, the list can, in theory, change when the user will add/remove languages used for address parsing. Namely, all languages listed in the parser, have the aliases represented in addition to the locale settings.

Maybe there is something else I am missing, let me know then. 