### PR TITLE
add osmscout car-tailored styles

### DIFF
--- a/maps/osmscout_car_day.json
+++ b/maps/osmscout_car_day.json
@@ -1,0 +1,11 @@
+{
+  "attribution": {
+    "OSM Scout Server": "https://github.com/rinigus/osmscout-server",
+    "© OpenStreetMap": "https://www.openstreetmap.org/copyright"
+  },
+  "first_label_layer": "waterway-name",
+  "format": "mapbox-gl",
+  "name": "OSM Scout Car Day",
+  "requires": ["harbour-osmscout-server"],
+  "style_url": "http://localhost:8553/v1/mbgl/style?style=osmbright-car"
+}

--- a/maps/osmscout_car_day_english.json
+++ b/maps/osmscout_car_day_english.json
@@ -1,0 +1,11 @@
+{
+  "attribution": {
+    "OSM Scout Server": "https://github.com/rinigus/osmscout-server",
+    "© OpenStreetMap": "https://www.openstreetmap.org/copyright"
+  },
+  "first_label_layer": "waterway-name",
+  "format": "mapbox-gl",
+  "name": "OSM Scout Car Day English",
+  "requires": ["harbour-osmscout-server"],
+  "style_url": "http://localhost:8553/v1/mbgl/style?style=osmbright-car-en"
+}

--- a/maps/osmscout_car_night.json
+++ b/maps/osmscout_car_night.json
@@ -1,0 +1,11 @@
+{
+  "attribution": {
+    "OSM Scout Server": "https://github.com/rinigus/osmscout-server",
+    "© OpenStreetMap": "https://www.openstreetmap.org/copyright"
+  },
+  "first_label_layer": "waterway-name",
+  "format": "mapbox-gl",
+  "name": "OSM Scout Car Night",
+  "requires": ["harbour-osmscout-server"],
+  "style_url": "http://localhost:8553/v1/mbgl/style?style=mc-car"
+}

--- a/maps/osmscout_car_night_english.json
+++ b/maps/osmscout_car_night_english.json
@@ -1,0 +1,11 @@
+{
+  "attribution": {
+    "OSM Scout Server": "https://github.com/rinigus/osmscout-server",
+    "© OpenStreetMap": "https://www.openstreetmap.org/copyright"
+  },
+  "first_label_layer": "waterway-name",
+  "format": "mapbox-gl",
+  "name": "OSM Scout Car Night English",
+  "requires": ["harbour-osmscout-server"],
+  "style_url": "http://localhost:8553/v1/mbgl/style?style=mc-car-en"
+}


### PR DESCRIPTION
This PR adds support for OSM Scout Server's car-tailored styles. At present, the styles are mainly increasing priority of such POIs as gas stations and parking. 