### PR TITLE
router module is not needed for osm scout server

### DIFF
--- a/routers/osmscout.json
+++ b/routers/osmscout.json
@@ -7,5 +7,5 @@
   "_modes": ["car", "bicycle", "foot"],
   "name": "OSM Scout",
   "offline": true,
-  "requires": ["harbour-osmscout-server", "harbour-osmscout-server-module-route"]
+  "requires": ["harbour-osmscout-server"]
 }


### PR DESCRIPTION
Starting from 1.8.0 of OSM Scout Server, the routing module is not required anymore. In addition, users that are preferring libosmscout didn't need it earlier either