### PR TITLE
add autocompletion support to OSM Scout geocoder

### DIFF
--- a/geocoders/osmscout.py
+++ b/geocoders/osmscout.py
@@ -43,7 +43,7 @@ def geocode(query, params):
     results = poor.http.get_json(url)
     results = list(map(poor.AttrDict, results))
     results = [dict(
-        label=result.title,
+        label=parse_label(result),
         title=result.title,
         description=parse_description(result),
         x=float(result.lng),
@@ -64,3 +64,10 @@ def parse_description(result):
     with poor.util.silent(Exception):
         items.append(result.admin_region)
     return ", ".join(items) or "–"
+
+def parse_label(result):
+    """Parse description from geocoding result."""
+    label = result.title
+    with poor.util.silent(Exception):
+        label = result.admin_region
+    return label

--- a/geocoders/osmscout.py
+++ b/geocoders/osmscout.py
@@ -31,7 +31,12 @@ cache = {}
 def autocomplete(query, x, y, params):
     """Return a list of autocomplete dictionaries matching `query`."""
     if len(query) < 3: return []
-    return geocode(query, params)
+    key = "autocomplete:{}".format(query)
+    with poor.util.silent(KeyError):
+        return copy.deepcopy(cache[key])
+    results = geocode(query, params)
+    cache[key] = copy.deepcopy(results)
+    return results
 
 def geocode(query, params):
     """Return a list of dictionaries of places matching `query`."""

--- a/geocoders/osmscout.py
+++ b/geocoders/osmscout.py
@@ -28,6 +28,11 @@ import urllib.parse
 URL = "http://localhost:8553/v1/search?limit={limit}&search={query}"
 cache = {}
 
+def autocomplete(query, x, y, params):
+    """Return a list of autocomplete dictionaries matching `query`."""
+    if len(query) < 3: return []
+    return geocode(query, params)
+
 def geocode(query, params):
     """Return a list of dictionaries of places matching `query`."""
     query = urllib.parse.quote_plus(query)
@@ -38,6 +43,7 @@ def geocode(query, params):
     results = poor.http.get_json(url)
     results = list(map(poor.AttrDict, results))
     results = [dict(
+        label=result.title,
         title=result.title,
         description=parse_description(result),
         x=float(result.lng),


### PR DESCRIPTION
This seems to be working. Several issues/questions:

* expected: when you type partial name of the city/country, libpostal may not recognize it and place it under category house (so, way off in hierarchy). To assist, users would have to enable primitive parser and add `,` in the search string. Or use this feature mainly to quickly find some restaurant by its name.

* unexpected: Looks like `filterCompletions` throws out results which may be valid, but not in its understanding. For example, searching for "Tallink Stockholm" would return "Tallink-Silja Line, Östermalms stadsdelsområde, Stockholm, Stockholm County, Svealand, 115 41, Sverige" with the title and label "Tallink-Silja Line, Östermalms stadsdelsområde". I wonder if there should be a property that would force to accept the completion if its coming from the geocoder? Notice that since we could search for Sweden and get Sverige in response. So, I would have trusted geocoder more than the text based filtering.

Question: What is the difference between `title` and `label`? In my case, I just put them the same.

I presume we need to resolve the issues before merging...