### PR TITLE
Add support for map matching

### DIFF
--- a/poor/application.py
+++ b/poor/application.py
@@ -51,6 +51,10 @@ class Application:
                         items.append(item)
         return items
 
+    def has_mapmatching(self):
+        """Return True if map matching requirements are met"""
+        return poor.util.requirement_found("harbour-osmscout-server")
+
     def quit(self):
         """Quit the application."""
         poor.http.pool.terminate()

--- a/poor/config.py
+++ b/poor/config.py
@@ -34,6 +34,9 @@ DEFAULTS = {
     "guide": "foursquare",
     # "always", "navigating" or "never".
     "keep_alive": "navigating",
+    # "none", "car", "bicycle", "foot"
+    "map_matching_when_idle": "none",
+    "map_matching_when_navigating": False,
     "map_scale": 1.0,
     "reroute": True,
     "router": "mapquest_open",

--- a/qml/Map.qml
+++ b/qml/Map.qml
@@ -40,7 +40,14 @@ MapboxMap {
     property bool   autoCenter: false
     property bool   autoRotate: false
     property int    counter: 0
-    property var    direction: app.navigationStatus.direction || gps.direction
+    property var    direction: {
+        // prefer map matched direction, if available
+        if (gps.directionValid) return gps.direction;
+        if (app.navigationStatus.direction!==undefined && app.navigationStatus.direction!==null)
+            return app.navigationStatus.direction;
+        if (gps.directionCalculated) return gps.direction;
+        return undefined;
+    }
     property string firstLabelLayer: ""
     property string format: ""
     property bool   hasRoute: false

--- a/qml/NavigationPage.qml
+++ b/qml/NavigationPage.qml
@@ -224,6 +224,20 @@ Page {
                 }
             }
 
+            TextSwitch {
+                id: mapmatchingSwitch
+                checked: enabled && app.conf.get("map_matching_when_navigating")
+                enabled: map.route.mode !== "transit"
+                text: app.tr("Snap position to road")
+                visible: app.hasMapMatching
+                onCheckedChanged: {
+                    if (!mapmatchingSwitch.enabled) return;
+                    app.conf.set("map_matching_when_navigating", mapmatchingSwitch.checked);
+                    if (mapmatchingSwitch.checked) app.mapMatchingModeNavigation=map.route.mode;
+                    else app.mapMatchingModeNavigation="none";
+                }
+            }
+
             Spacer {
                 height: Theme.paddingMedium
             }

--- a/qml/NavigationStatus.qml
+++ b/qml/NavigationStatus.qml
@@ -23,7 +23,7 @@ QtObject {
 
     property string destDist:  ""
     property string destTime:  ""
-    property var    direction: null
+    property var    direction: undefined
     property string icon:      ""
     property string manDist:   ""
     property string manTime:   ""
@@ -39,7 +39,7 @@ QtObject {
         // Reset all navigation status properties.
         status.destDist  = "";
         status.destTime  = "";
-        status.direction = null;
+        status.direction = undefined;
         status.icon      = "";
         status.manDist   = "";
         status.manTime   = "";
@@ -56,7 +56,8 @@ QtObject {
         if (!data) return;
         status.destDist  = data.dest_dist  || "";
         status.destTime  = data.dest_time  || "";
-        status.direction = data.direction  || null;
+        if (data.direction !== undefined && data.direction !== null) status.direction = data.direction;
+        else status.direction = undefined;
         status.icon      = data.icon       || "";
         status.manDist   = data.man_dist   || "";
         status.manTime   = data.man_time   || "";

--- a/qml/PositionMarker.qml
+++ b/qml/PositionMarker.qml
@@ -54,12 +54,23 @@ Item {
         map.setLayoutProperty(marker.layers.still, "icon-image", marker.images.still);
         map.setLayoutProperty(marker.layers.still, "icon-rotation-alignment", "map");
         map.setLayoutProperty(marker.layers.still, "icon-size", 1 / map.pixelRatio);
-        map.setLayoutProperty(marker.layers.still, "visibility", "visible");
         map.setLayoutProperty(marker.layers.moving, "icon-allow-overlap", true);
         map.setLayoutProperty(marker.layers.moving, "icon-image", marker.images.moving);
         map.setLayoutProperty(marker.layers.moving, "icon-rotation-alignment", "map");
         map.setLayoutProperty(marker.layers.moving, "icon-size", 1 / map.pixelRatio);
-        map.setLayoutProperty(marker.layers.moving, "visibility", "none");
+        // set the layer immediately in accordence with the direction availibility.
+        // there seems to be a corner case in interaction with mapbox-gl qml when the layer
+        // visibility is changed in two consecutive calls before the changes are applied by
+        // the widget
+        if (map.direction!==undefined) {
+            map.setLayoutProperty(marker.layers.still, "visibility", "none");
+            map.setLayoutProperty(marker.layers.moving, "visibility", "visible");
+            marker.directionVisible = true;
+        } else if (map.direction===undefined) {
+            map.setLayoutProperty(marker.layers.still, "visibility", "visible");
+            map.setLayoutProperty(marker.layers.moving, "visibility", "none");
+            marker.directionVisible = false;
+        }
     }
 
     function initLayers() {
@@ -71,11 +82,11 @@ Item {
     }
 
     function updateDirection() {
-        if (map.direction && !marker.directionVisible) {
+        if (map.direction!==undefined && !marker.directionVisible) {
             map.setLayoutProperty(marker.layers.still, "visibility", "none");
             map.setLayoutProperty(marker.layers.moving, "visibility", "visible");
             marker.directionVisible = true;
-        } else if (!map.direction && marker.directionVisible) {
+        } else if (map.direction===undefined && marker.directionVisible) {
             map.setLayoutProperty(marker.layers.still, "visibility", "visible");
             map.setLayoutProperty(marker.layers.moving, "visibility", "none");
             marker.directionVisible = false;

--- a/qml/PositionSource.qml
+++ b/qml/PositionSource.qml
@@ -51,6 +51,14 @@ PositionSourceMapMatched {
         if (gps.active) gps.timeActivate = Date.now();
     }
 
+    onDirectionValidChanged: {
+        // Clear direction if we switchid to map matched directions
+        if (!directionValid) return;
+        gps.coordHistory = [];
+        gps.directionCalculated = false;
+        gps.directionHistory = [];
+    }
+
     onPositionChanged: {
         // proceed only if map matching does not provide direction
         if (directionValid) return;
@@ -83,7 +91,7 @@ PositionSourceMapMatched {
                 gps.timeDirection = Date.now();
                 gps.directionCalculated = true;
             }
-        } else if (gps.direction && Date.now() - gps.timeDirection > 300000) {
+        } else if (gps.directionCalculated && Date.now() - gps.timeDirection > 300000) {
             // Clear direction if we have not seen any valid updates in a while.
             gps.coordHistory = [];
             gps.directionCalculated = false;
@@ -91,11 +99,4 @@ PositionSourceMapMatched {
         }
     }
 
-    onDirectionValidChanged: {
-        // Clear direction if we switchid to map matched directions
-        if (!directionValid) return;
-        gps.coordHistory = [];
-        gps.directionCalculated = false;
-        gps.directionHistory = [];
-    }
 }

--- a/qml/PositionSource.qml
+++ b/qml/PositionSource.qml
@@ -32,7 +32,7 @@ PositionSourceMapMatched {
 
     mapMatchingMode: {
         if (app.mapMatchingMode == "none") return 0;
-        else if (app.mapMatchingMode == "car") return 2;
+        else if (app.mapMatchingMode == "car") return 1;
         else if (app.mapMatchingMode == "bicycle") return 3;
         else if (app.mapMatchingMode == "foot") return 5;
         return 0;

--- a/qml/PositionSourceMapMatched.qml
+++ b/qml/PositionSourceMapMatched.qml
@@ -1,0 +1,291 @@
+/* -*- coding: utf-8-unix -*-
+ *
+ * Copyright 2018 Rinigus <rinigus.git@gmail.com>
+ * 
+ * MIT License
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+import QtQuick 2.0
+import QtPositioning 5.3
+import Nemo.DBus 2.0
+
+Item {
+    id: master
+
+    // Properties
+    property alias active: gps.active
+    property real  direction: 0
+    property bool  directionValid: false
+    property alias mapMatchingAvailable: scoutbus.available
+    property alias mapMatchingMode: scoutbus.mode
+    property alias name: gps.name
+    property var   position: gps.position
+    property alias preferredPositioningMethods: gps.preferredPositioningMethods
+    property alias sourceError: gps.sourceError
+    property string streetName: ""
+    property real  streetSpeedAssumed: -1  // in m/s
+    property real  streetSpeedLimit: -1    // in m/s
+    property alias supportedPositioningMethods: gps.supportedPositioningMethods
+    property alias updateInterval: gps.updateInterval
+    property alias valid: gps.valid
+
+    // Timing statistics support
+    property bool  timingStatsEnable: false
+    property real  timingOverallAvr: 0
+    property real  timingOverallMax: 0
+    property real  timingOverallMin: -1
+
+    // Timing statistics support - internal vars
+    property int   _timingOverallCounter: 0
+    property real  _timingOverallSum: 0.0
+    property bool  _timingShot: false
+    property var   _timingLastCallStart: undefined
+
+    // Properties used for testing
+    property var   testingCoordinate: undefined
+
+    // Signals
+
+    // signal is not provided by Sailfish version of PositionSource
+    // signal updateTimeout()
+
+    // Methods
+    function start() {
+        gps.start()
+    }
+
+    function stop() {
+        gps.stop()
+    }
+
+    function update() {
+        gps.update()
+    }
+
+    //////////////////////////////////////////////////////////////
+    /// Implementation
+    //////////////////////////////////////////////////////////////
+
+    // provider for actual position
+    PositionSource {
+        id: gps
+
+        function positionUpdate(position) {
+            if (scoutbus.available &&
+                    scoutbus.mode &&
+                    position.latitudeValid && position.longitudeValid &&
+                    position.horizontalAccuracyValid) {
+                if (master.timingStatsEnable && !master._timingShot) {
+                    master._timingOverallCounter += 1;
+                    master._timingShot = true;
+                    master._timingLastCallStart = Date.now();
+                }
+                scoutbus.mapMatch(position);
+            } else {
+                master.position = position;
+                if (scoutbus.mode && scoutbus.running)
+                    scoutbus.stop();
+            }
+        }
+
+        onPositionChanged: positionUpdate(position)
+
+        onActiveChanged: {
+            if (!gps.active) scoutbus.stop();
+        }
+
+        //onUpdateTimeout: master.updateTimeout()
+    }
+
+    // interaction with OSM Scout Server via D-Bus
+    DBusInterface {
+        id: scoutbus
+        service: "org.osm.scout.server1"
+        path: "/org/osm/scout/server1/mapmatching1"
+        iface: "org.osm.scout.server1.mapmatching1"
+
+        property bool available: false
+        property int  mode: 0
+        property bool running: false;
+
+        Component.onCompleted: {
+            checkAvailable();
+        }
+
+        function checkAvailable() {
+            if (getProperty("Active")) {
+                if (!available) {
+                    available = true;
+                    if (mode) call('Reset', mode);
+                    resetValues();
+                }
+            } else {
+                available = false
+                resetValues();
+            }
+        }
+
+        function mapMatch(position) {
+            if (!mode || !available) return;
+
+            typedCall("Update",
+                      [ {'type': 'i', 'value': mode},
+                       {'type': 'd', 'value': position.coordinate.latitude},
+                       {'type': 'd', 'value': position.coordinate.longitude},
+                       {'type': 'd', 'value': position.horizontalAccuracy} ],
+                      function(result) {
+                          // successful call
+                          var r = JSON.parse(result);
+                          var position = {}
+                          for (var i in gps.position) {
+                              if (!(gps.position[i] instanceof Function) && i!=="coordinate")
+                                  position[i] = gps.position[i]
+                          }
+
+                          var latitude = master.position.coordinate.latitude
+                          var longitude = master.position.coordinate.longitude
+                          if (r.latitude !== undefined) latitude = r.latitude;
+                          if (r.longitude !== undefined) longitude = r.longitude;
+                          position.coordinate = QtPositioning.coordinate(latitude, longitude);
+
+                          if (r.direction!==undefined) master.direction = r.direction;
+                          if (r.direction_valid!==undefined) master.directionValid = r.direction_valid;
+                          if (r.street_name!==undefined) master.streetName = r.street_name;
+                          if (r.street_speed_assumed!==undefined) master.streetSpeedAssumed = r.street_speed_assumed;
+                          if (r.street_speed_limit!==undefined) master.streetSpeedLimit = r.street_speed_limit;
+
+                          // always update position
+                          master.position = position;
+
+                          if (master._timingShot) {
+                              var dt = 1e-3*(Date.now() - master._timingLastCallStart);
+                              master._timingShot = false;
+                              master._timingOverallSum += dt;
+                              if (master.timingOverallMax < dt) master.timingOverallMax = dt;
+                              if (master.timingOverallMin<0 || master.timingOverallMin > dt) master.timingOverallMin = dt;
+                              master.timingOverallAvr = master._timingOverallSum/master._timingOverallCounter;
+                          }
+                      },
+                      function(result) {
+                          // error
+                          scoutbus.resetValues();
+                          master.position = gps.position;
+                      }
+                      );
+
+            running = true;
+        }
+
+        function resetValues() {
+            master.directionValid = false;
+            master.streetName = ""
+            master.streetSpeedAssumed = -1;
+            master.streetSpeedLimit = -1;
+        }
+
+        function stop() {
+            if (mode) {
+                call('Stop', mode);
+                if (gps.active) resetValues();
+            }
+            running = false;
+        }
+
+        onModeChanged: {
+            if (!available) return;
+            if (mode) call('Reset', mode);
+            resetValues();
+        }
+    }
+
+    // monitor availibility of OSM Scout Server on D-Bus
+    DBusInterface {
+        // monitors availibility of the dbus service
+        service: "org.freedesktop.DBus"
+        path: "/org/freedesktop/DBus"
+        iface: "org.freedesktop.DBus"
+        signalsEnabled: true
+
+        function nameOwnerChanged(name, old_owner, new_owner) {
+            if (name === scoutbus.service)
+                scoutbus.checkAvailable()
+        }
+    }
+
+    // start OSM Scout Server via systemd socket activation
+    // if the server is not available, but needed
+    Timer {
+        id: activationTimer
+        interval: 5000
+        repeat: true
+        running: scoutbus.mode > 0 && !scoutbus.available
+        onTriggered: {
+            console.log('Activating OSM Scout Server');
+
+            var xmlhttp = new XMLHttpRequest();
+            xmlhttp.open("GET",
+                         "http://localhost:8553/v1/activate",
+                         true);
+            xmlhttp.send();
+        }
+    }
+
+    // support for testing
+    Timer {
+        id: testingTimer
+        interval: gps.updateInterval
+        running: false
+        repeat: true
+        onTriggered: {
+            var p= {};
+            p.coordinate = master.testingCoordinate;
+            p.horizontalAccuracy = 10;
+            p.latitudeValid = true;
+            p.longitudeValid = true;
+            p.horizontalAccuracyValid = true;
+            gps.positionUpdate(p);
+        }
+    }
+
+    onTimingStatsEnableChanged: {
+        // reset if timing stats started
+        if (timingStatsEnable) {
+            timingOverallAvr = 0;
+            timingOverallMax = 0;
+            timingOverallMin = -1;
+
+            _timingOverallCounter = 0;
+            _timingOverallSum = 0.0;
+            _timingShot = false;
+        }
+    }
+
+    onTestingCoordinateChanged: {
+        if (testingCoordinate==null) {
+            testingTimer.running = false;
+        } else {
+            testingTimer.running = true;
+        }
+    }
+}

--- a/qml/PreferencesPage.qml
+++ b/qml/PreferencesPage.qml
@@ -103,6 +103,29 @@ Page {
             }
 
             ComboBox {
+                id: mapmatchingComboBox
+                description: app.tr("Select mode of transportation. Only applies when WhoGo Maps is not navigating.")
+                label: app.tr("Snap position to road")
+                menu: ContextMenu {
+                    MenuItem { text: app.tr("None") }
+                    MenuItem { text: app.tr("Car") }
+                    MenuItem { text: app.tr("Bicycle") }
+                    MenuItem { text: app.tr("Foot") }
+                }
+                visible: app.hasMapMatching
+                property var values: ["none", "car", "bicycle", "foot"]
+                Component.onCompleted: {
+                    var value = app.conf.get("map_matching_when_idle");
+                    mapmatchingComboBox.currentIndex = mapmatchingComboBox.values.indexOf(value);
+                }
+                onCurrentIndexChanged: {
+                    var index = mapmatchingComboBox.currentIndex;
+                    app.conf.set("map_matching_when_idle", mapmatchingComboBox.values[index]);
+                    app.updateMapMatching();
+                }
+            }
+
+            ComboBox {
                 id: unitsComboBox
                 label: app.tr("Units")
                 menu: ContextMenu {

--- a/qml/whogo-maps.qml
+++ b/qml/whogo-maps.qml
@@ -40,7 +40,15 @@ ApplicationWindow {
     property var  attributionButton: null
     property var  centerButton: null
     property var  conf: Config {}
+    property bool hasMapMatching: false
     property var  map: null
+    property string mapMatchingMode: {
+        if (!hasMapMatching) return "none";
+        if (navigationActive) return mapMatchingModeNavigation;
+        return mapMatchingModeIdle;
+    }
+    property string mapMatchingModeIdle: "none"
+    property string mapMatchingModeNavigation: "none"
     property var  menuButton: null
     property var  meters: null
     property var  narrativePageSeen: false
@@ -75,6 +83,10 @@ ApplicationWindow {
         autoLoad: true
         autoPlay: true
         loops: 1
+    }
+
+    Component.onCompleted: {
+        updateMapMatching()
     }
 
     Component.onDestruction: {
@@ -238,6 +250,13 @@ ApplicationWindow {
         var prevent = app.conf.get("keep_alive");
         DisplayBlanking.preventBlanking = app.applicationActive &&
             (prevent === "always" || (prevent === "navigating" && app.navigationActive));
+    }
+
+    function updateMapMatching() {
+        if (!py.ready) return py.onReadyChanged.connect(app.updateMapMatching);
+        app.hasMapMatching = py.call_sync("poor.app.has_mapmatching", []);
+        app.mapMatchingModeIdle = app.conf.get("map_matching_when_idle");
+        // app.mapMatchingModeNavigation is set on Navigation page
     }
 
     function updateNavigationStatus(status) {

--- a/routers/mapquest_open.py
+++ b/routers/mapquest_open.py
@@ -53,6 +53,12 @@ ICONS = {
     18: "fork-straight",
 }
 
+MODE = {
+    "fastest": "car",
+    "bicycle": "bicycle",
+    "pedestrian": "foot"
+}
+
 SUPPORTED_LOCALES = [
     "en_US",
     "en_GB",
@@ -116,7 +122,8 @@ def route(fm, to, heading, params):
     if len(maneuvers) > 1:
         maneuvers[ 0]["icon"] = "depart"
         maneuvers[-1]["icon"] = "arrive"
-    route = dict(x=x, y=y, maneuvers=maneuvers, mode="car")
+    mode = MODE.get(type,"car")
+    route = dict(x=x, y=y, maneuvers=maneuvers, mode=mode)
     route["language"] = locale
     if route and route["x"]:
         cache[url] = copy.deepcopy(route)


### PR DESCRIPTION
This PR adds support for map matching through communication with OSM Scout Server, fixes #49. PR consists of three commits, organized as follows.

First, the route mode now can  have values specifying cycling and pedestrian transportation. This is later used to select specific map matching mode.

Second, direction can have zero as a value which, in the earlier versions, may lead to value of `null` being set for it. In addition, while testing, I encountered that on PositionMarker initialization, if map.direction was some meaningful value, the changes in visibility of the layers were not propagated. I suspect that its some kind of bug in my bindings of MapboxGL. So, at least for now, correct visibility initialization resolves the issue.

Third, the addition of map matching support. For that, PositionSourceMapMatched.qml has been added to the tree and used in PositionSource. I have added check on whether map matching support is possible (test whether harbour-osmscout-server is available on start). When not possible, all map matching settings are invisible and PositionSourceMapMatched works as an alias for classical PositionSource. Users are setting map matching options in Preferences (if they wish to have it while in idle mode) and Navigation (if they wish to have map matching available while navigating). While in idle, users have to specify transportation mode, in navigation, the route mode is used.

At present, map matching does not support "transit" mode. I am looking into possibility of inclusion of transit.land data into Valhalla, but have problems with downloading it. Also, I don't know how well would it work in this case. So, probably this limitation will stay for a while.


