### PR TITLE
Support for nearby search along the route

### DIFF
--- a/guides/osmscout.py
+++ b/guides/osmscout.py
@@ -88,11 +88,11 @@ def nearby(query, near, radius, params):
     else:
         search = urllib.parse.quote_plus(near)
         url = URL_SEARCH.format(**locals())
-    # with poor.util.silent(KeyError):
-    #     return copy.deepcopy(cache[url])
     if route_search:
         results = poor.http.post_json(url, json.dumps(route))
     else:
+        with poor.util.silent(KeyError):
+            return copy.deepcopy(cache[url])
         results = poor.http.get_json(url)
     results = poor.AttrDict(results)
     x = float(results.origin.lng)
@@ -104,8 +104,8 @@ def nearby(query, near, radius, params):
         x=float(result.lng),
         y=float(result.lat),
     ) for result in results.results]
-    # if results and results[0]:
-    #     cache[url] = copy.deepcopy((x, y, results))
+    if not route_search and results and results[0]:
+        cache[url] = copy.deepcopy((x, y, results))
     return x, y, results
 
 def normalize(t):

--- a/guides/osmscout_settings.qml
+++ b/guides/osmscout_settings.qml
@@ -38,4 +38,47 @@ Column {
             page.params.name = ""
         }
     }
+
+    TextSwitch {
+        id: routeSwitch
+        anchors.left: parent.left
+        anchors.right: parent.right
+        checked: page.params.alongRoute
+        text: app.tr("Search along the route")
+        visible: map.hasRoute
+
+        function update() {
+            if (!map.hasRoute) {
+                routeSwitch.checked = false;
+            }
+            if (routeSwitch.checked) {
+                page.params.alongRoute = true;
+                page.params.route = { "route_lng": map.route.x, "route_lat": map.route.y };
+            } else {
+                page.params.alongRoute = false;
+            }
+        }
+
+        onCheckedChanged: routeSwitch.update()
+        Component.onCompleted: routeSwitch.update()
+    }
+
+    TextSwitch {
+        id: fromRefSwitch
+        anchors.left: parent.left
+        anchors.right: parent.right
+        checked: page.params.fromReference
+        text: app.tr("Search starting from the reference point")
+        visible: map.hasRoute && routeSwitch.checked
+
+        function update() {
+            page.params.fromReference = fromRefSwitch.checked;
+        }
+
+        onCheckedChanged: fromRefSwitch.update()
+        Component.onCompleted: {
+            fromRefSwitch.checked = true;
+            fromRefSwitch.update();
+        }
+    }
 }

--- a/guides/osmscout_settings.qml
+++ b/guides/osmscout_settings.qml
@@ -43,7 +43,7 @@ Column {
         id: routeSwitch
         anchors.left: parent.left
         anchors.right: parent.right
-        checked: page.params.alongRoute
+        checked: page.params.alongRoute!==undefined && page.params.alongRoute
         text: app.tr("Search along the route")
         visible: map.hasRoute
 
@@ -67,7 +67,8 @@ Column {
         id: fromRefSwitch
         anchors.left: parent.left
         anchors.right: parent.right
-        checked: page.params.fromReference
+        checked: page.params.fromReference!==undefined && page.params.fromReference
+        description: app.tr("When set, the search along the route is performed starting from the point specified by 'Near' on this page") 
         text: app.tr("Search starting from the reference point")
         visible: map.hasRoute && routeSwitch.checked
 

--- a/poor/guide.py
+++ b/poor/guide.py
@@ -86,9 +86,8 @@ class Guide:
         return (hasattr(self._provider, "autocomplete_type") and
                 callable(self._provider.autocomplete_type))
 
-    def _format_distance(self, x1, y1, x2, y2):
-        """Calculate and format a human readable distance string."""
-        distance = poor.util.calculate_distance(x1, y1, x2, y2)
+    def _format_distance(self, x1, y1, x2, y2, distance):
+        """Format distance in a human readable distance string."""
         bearing  = poor.util.calculate_bearing(x1, y1, x2, y2)
         return poor.util.format_distance_and_bearing(distance, bearing)
 
@@ -127,14 +126,13 @@ class Guide:
             traceback.print_exc()
             return []
         for result in results:
-            result["distance"] = poor.util.calculate_distance(
-                x, y, result["x"], result["y"])
+            if "distance" not in result:
+                result["distance"] = poor.util.calculate_distance(
+                    x, y, result["x"], result["y"])
             result["provider"] = self.id
-        # Enforce radius in case the provider didn't.
-        results = [z for z in results if z["distance"] <= radius]
         for result in results:
             result["distance"] = self._format_distance(
-                x, y, result["x"], result["y"])
+                x, y, result["x"], result["y"], result["distance"])
         return results
 
     @property

--- a/qml/Map.qml
+++ b/qml/Map.qml
@@ -202,6 +202,8 @@ MapboxMap {
             "language": route.language || "en",
             "mode": route.mode || "car",
             "provider": route.provider || "",
+            "x": route.x,
+            "y": route.y
         };
         py.call("poor.app.narrative.set_mode", [route.mode || "car"], null);
         py.call("poor.app.narrative.set_route", [route.x, route.y], function() {


### PR DESCRIPTION
This PR adds support for search along the route, supported by OSM Scout Server from version 1.10.0. As such, its nearby search and the user can specify whether its performed next to the point or along the route.

I changed the handling of the distance in poor/guide.py. Here, it calculates the distance only if the plugin does not specify distance by itself. This is done since the distance in the search along the route represents not the distance from route, but along it before reaching the point where POI is nearby. 